### PR TITLE
Add svg-themer library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# ThemeBasedSVG
+# svg-themer
+
+A lightweight Kotlin Multiplatform library for displaying SVG images that adapt to the current theme.
+
+## Features
+
+- Works with JetBrains Compose Multiplatform (Android & iOS).
+- Replaces color tokens in an SVG string at runtime.
+- Provides a composable `rememberThemedSvgPainter` for easy use in Compose UI.
+- Plain API to rasterize SVG text to `ImageBitmap` or PNG bytes.
+- Includes a small Compose Desktop sample in [`sample/`](sample) demonstrating usage.
+
+## Usage
+
+SVG files can contain placeholders using `{{token}}` syntax. Provide colors for light and dark themes via `TokenColors`:
+
+```kotlin
+val tokens = TokenColors(
+    light = mapOf("primary" to Color(0xFF6200EE)),
+    dark = mapOf("primary" to Color(0xFFBB86FC))
+)
+```
+
+In Compose:
+
+```kotlin
+Image(
+    painter = rememberThemedSvgPainter(svgText, tokens),
+    contentDescription = null
+)
+```
+
+For non‑UI usage:
+
+```kotlin
+val bitmap: ImageBitmap = rasterizeSvgToImageBitmap(svgText)
+val png: ByteArray = rasterizeSvgToPngBytes(svgText)
+```
+
+All color substitution is performed directly on the SVG text before parsing so the runtime footprint stays small.
+
+## Sample project
+
+Run the Compose Desktop demo with:
+
+```bash
+gradle :sample:run
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    kotlin("multiplatform") version "1.9.21"
+    id("org.jetbrains.compose") version "1.6.0"
+    id("com.android.library") version "8.2.2"
+}
+
+kotlin {
+    androidTarget()
+    jvm()
+    iosArm64()
+    iosX64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.ui)
+            }
+        }
+        val androidMain by getting
+        val jvmMain by getting
+        val iosMain by creating {
+            dependsOn(commonMain)
+        }
+        val iosArm64Main by getting { dependsOn(iosMain) }
+        val iosX64Main by getting { dependsOn(iosMain) }
+        val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+    }
+}
+
+android {
+    compileSdk = 34
+    defaultConfig {
+        minSdk = 24
+    }
+    namespace = "svg.themer"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.code.style=official

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    kotlin("jvm") version "1.9.21"
+    id("org.jetbrains.compose") version "1.6.0"
+    application
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":"))
+    implementation(compose.desktop.currentOs)
+}
+
+compose.desktop {
+    application {
+        mainClass = "sample.main.MainKt"
+    }
+}

--- a/sample/src/main/kotlin/sample/main/Main.kt
+++ b/sample/src/main/kotlin/sample/main/Main.kt
@@ -1,0 +1,31 @@
+package sample.main
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import svg.themer.TokenColors
+import svg.themer.rememberThemedSvgPainter
+
+fun main() = application {
+    Window(onCloseRequest = ::exitApplication) {
+        SampleContent()
+    }
+}
+
+@Composable
+fun SampleContent() {
+    val svgText = """
+        <svg width="100" height="100">
+            <rect width="100" height="100" fill="{{primary}}" />
+        </svg>
+    """.trimIndent()
+
+    val tokens = TokenColors(
+        light = mapOf("primary" to Color(0xFF6200EE)),
+        dark = mapOf("primary" to Color(0xFFBB86FC))
+    )
+
+    Image(painter = rememberThemedSvgPainter(svgText, tokens), contentDescription = null)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+include(":sample")
+
+rootProject.name = "svg-themer"

--- a/src/androidMain/kotlin/svg/themer/SvgRasterizer.android.kt
+++ b/src/androidMain/kotlin/svg/themer/SvgRasterizer.android.kt
@@ -1,0 +1,30 @@
+package svg.themer
+
+import android.graphics.Bitmap
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import org.jetbrains.skia.Data
+import org.jetbrains.skia.Surface
+import org.jetbrains.skia.svg.SVGDOM
+import java.io.ByteArrayOutputStream
+
+actual fun rasterizeSvgToImageBitmap(svgText: String, width: Int?, height: Int?): ImageBitmap {
+    val dom = SVGDOM(Data.makeFromBytes(svgText.encodeToByteArray()))
+    val w = width ?: dom.containerSize.width.toInt()
+    val h = height ?: dom.containerSize.height.toInt()
+    dom.setContainerSize(w.toFloat(), h.toFloat())
+    val surface = Surface.makeRasterN32Premul(w, h)
+    val canvas = surface.canvas
+    canvas.clear(0)
+    dom.render(canvas)
+    val snapshot = surface.makeImageSnapshot()
+    return snapshot.toComposeImageBitmap()
+}
+
+actual fun encodeImageBitmapAsPng(bitmap: ImageBitmap): ByteArray {
+    val bmp = bitmap.asAndroidBitmap()
+    val out = ByteArrayOutputStream()
+    bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
+    return out.toByteArray()
+}

--- a/src/commonMain/kotlin/svg/themer/SvgColorThemer.kt
+++ b/src/commonMain/kotlin/svg/themer/SvgColorThemer.kt
@@ -1,0 +1,32 @@
+package svg.themer
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Maps placeholder tokens in an SVG string to [Color] values for light and dark themes.
+ */
+data class TokenColors(
+    val light: Map<String, Color>,
+    val dark: Map<String, Color>
+)
+
+/**
+ * Replace placeholder tokens in the provided SVG [text] using [colors].
+ * Placeholders use the form `{{token}}`.
+ */
+fun applyColorTokens(text: String, colors: Map<String, Color>): String {
+    var out = text
+    for ((token, color) in colors) {
+        val hex = color.toHexString()
+        out = out.replace("{{$token}}", hex, ignoreCase = true)
+    }
+    return out
+}
+
+private fun Color.toHexString(): String {
+    val a = (alpha * 255).toInt().toString(16).padStart(2, '0')
+    val r = (red * 255).toInt().toString(16).padStart(2, '0')
+    val g = (green * 255).toInt().toString(16).padStart(2, '0')
+    val b = (blue * 255).toInt().toString(16).padStart(2, '0')
+    return "#$r$g$b$a"
+}

--- a/src/commonMain/kotlin/svg/themer/SvgRasterizer.kt
+++ b/src/commonMain/kotlin/svg/themer/SvgRasterizer.kt
@@ -1,0 +1,16 @@
+package svg.themer
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+/** Platform implementation to convert an SVG string to [ImageBitmap]. */
+expect fun rasterizeSvgToImageBitmap(svgText: String, width: Int? = null, height: Int? = null): ImageBitmap
+
+/**
+ * Rasterize an SVG and return PNG encoded bytes.
+ */
+fun rasterizeSvgToPngBytes(svgText: String, width: Int? = null, height: Int? = null): ByteArray {
+    val bitmap = rasterizeSvgToImageBitmap(svgText, width, height)
+    return encodeImageBitmapAsPng(bitmap)
+}
+
+expect fun encodeImageBitmapAsPng(bitmap: ImageBitmap): ByteArray

--- a/src/commonMain/kotlin/svg/themer/ThemedSvgPainter.kt
+++ b/src/commonMain/kotlin/svg/themer/ThemedSvgPainter.kt
@@ -1,0 +1,22 @@
+package svg.themer
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalDensity
+
+/**
+ * Create a [Painter] for the provided SVG text with colors automatically
+ * switched for the current theme.
+ */
+@Composable
+fun rememberThemedSvgPainter(svgText: String, tokens: TokenColors): Painter {
+    val dark = isSystemInDarkTheme()
+    val colors = if (dark) tokens.dark else tokens.light
+    val density = LocalDensity.current
+    val processed = remember(svgText, colors) { applyColorTokens(svgText, colors) }
+    val bitmap = remember(processed, density) { rasterizeSvgToImageBitmap(processed) }
+    return remember(bitmap) { BitmapPainter(bitmap) }
+}

--- a/src/iosMain/kotlin/svg/themer/SvgRasterizer.ios.kt
+++ b/src/iosMain/kotlin/svg/themer/SvgRasterizer.ios.kt
@@ -1,0 +1,26 @@
+package svg.themer
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toImageBitmap
+import org.jetbrains.skia.Data
+import org.jetbrains.skia.Surface
+import org.jetbrains.skia.svg.SVGDOM
+
+actual fun rasterizeSvgToImageBitmap(svgText: String, width: Int?, height: Int?): ImageBitmap {
+    val dom = SVGDOM(Data.makeFromBytes(svgText.encodeToByteArray()))
+    val w = width ?: dom.containerSize.width.toInt()
+    val h = height ?: dom.containerSize.height.toInt()
+    dom.setContainerSize(w.toFloat(), h.toFloat())
+    val surface = Surface.makeRasterN32Premul(w, h)
+    val canvas = surface.canvas
+    canvas.clear(0)
+    dom.render(canvas)
+    val snapshot = surface.makeImageSnapshot()
+    return snapshot.toComposeImageBitmap()
+}
+
+actual fun encodeImageBitmapAsPng(bitmap: ImageBitmap): ByteArray {
+    val skImage = bitmap.asSkiaImage()
+    val data = skImage.encodeToData()
+    return data?.bytes ?: ByteArray(0)
+}

--- a/src/jvmMain/kotlin/svg/themer/SvgRasterizer.jvm.kt
+++ b/src/jvmMain/kotlin/svg/themer/SvgRasterizer.jvm.kt
@@ -1,0 +1,25 @@
+package svg.themer
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asSkiaImage
+import org.jetbrains.skia.Data
+import org.jetbrains.skia.Surface
+import org.jetbrains.skia.svg.SVGDOM
+
+actual fun rasterizeSvgToImageBitmap(svgText: String, width: Int?, height: Int?): ImageBitmap {
+    val dom = SVGDOM(Data.makeFromBytes(svgText.encodeToByteArray()))
+    val w = width ?: dom.containerSize.width.toInt()
+    val h = height ?: dom.containerSize.height.toInt()
+    dom.setContainerSize(w.toFloat(), h.toFloat())
+    val surface = Surface.makeRasterN32Premul(w, h)
+    val canvas = surface.canvas
+    canvas.clear(0)
+    dom.render(canvas)
+    val snapshot = surface.makeImageSnapshot()
+    return snapshot.toComposeImageBitmap()
+}
+
+actual fun encodeImageBitmapAsPng(bitmap: ImageBitmap): ByteArray {
+    val data = bitmap.asSkiaImage().encodeToData()
+    return data?.bytes ?: ByteArray(0)
+}


### PR DESCRIPTION
## Summary
- create multiplatform build files and gradle config
- implement color token replacement and themed Painter
- provide rasterization APIs for Android & iOS
- document library usage in README
- add Compose Desktop sample and JVM target

## Testing
- `gradle :sample:build --no-daemon --stacktrace` *(fails to download Kotlin/Native compiler: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a598a08c0832cb166d25add16b1e9